### PR TITLE
Add 'is' getters

### DIFF
--- a/src/Traits/HasPropertyAccessors.php
+++ b/src/Traits/HasPropertyAccessors.php
@@ -25,6 +25,10 @@ trait HasPropertyAccessors
         $studly_key = Transformer::studly($key);
         $accessor = 'get' . $studly_key . 'Property';
 
+        if (!method_exists($this, $accessor)) {
+            $accessor = 'is' . $studly_key . 'Property';
+        }
+
         return method_exists($this, $accessor);
     }
 


### PR DESCRIPTION
Add getters with the form `isVarProperty`. This are usually used for boolean properties.